### PR TITLE
feat: implement DepartureBeforeNowFilter

### DIFF
--- a/src/com/gridnine/testing/DepartureBeforeNowFilter.java
+++ b/src/com/gridnine/testing/DepartureBeforeNowFilter.java
@@ -1,0 +1,20 @@
+package com.gridnine.testing;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class DepartureBeforeNowFilter implements FlightFilter {
+    @Override
+    public boolean test(Flight flight) {
+        if (flight == null) {
+            throw new IllegalArgumentException("Некорректные данные перелета");
+        }
+        List<Segment> segments = flight.getSegments();
+
+        if (segments.isEmpty()) {
+            return false;
+        }
+
+        return !segments.get(0).getDepartureDate().isBefore(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
- Create filter to exclude flights with departure before current time
- Check first segment departure date using isBefore() method
- Add null safety checks for flight and segments list
- Handle empty segments case by returning false

Resolves: #3